### PR TITLE
Add the API error messages to client errors

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -39,9 +39,12 @@ class Client {
     return new Promise((resolve, reject) => {
       request(options, (error, response, body) => {
         if (error) {
+          error.errorMessages = [error.message]
           reject(error)
         } else if (!(response.statusCode.toString().match(/2[\d]{2}/))) {
-          reject(new Error(response.statusCode.toString()))
+          var apiError = new Error(response.statusMessage)
+          apiError.errorMessages = response.body.errors
+          reject(apiError)
         } else {
           resolve(body)
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swiftype-app-search-node",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Swiftype app-search Node.js client",
   "files": [
     "lib/"


### PR DESCRIPTION
The API returns an array of error messages in the response body of things like `400 Bad Request` responses. This exposes them on the error that is returned.