### PR TITLE
Use api key names for signed search keys rather than ids

### DIFF
--- a/lib/swiftypeAppSearch.js
+++ b/lib/swiftypeAppSearch.js
@@ -87,15 +87,15 @@ class SwiftypeAppSearchClient {
    * Creates a jwt search key that can be used for authentication to enforce a set of required search options.
    *
    * @param {String} apiKey the API Key used to sign the search key
-   * @param {String} apiKeyId the unique API Key identifier
+   * @param {String} apiKeyName the unique name for the API Key
    * @param {Object} options Object see the <a href="https://swiftype.com/documentation/app-search/">App Search API</a> for supported search options
    * @returns {String} jwt search key
    */
-  static createSignedSearchKey(apiKey, apiKeyId, options = {}) {
+  static createSignedSearchKey(apiKey, apiKeyName, options = {}) {
     if (!apiKey.match(/^api/)) {
       throw new Error('Must sign search options with an API Key, cannot use a search-only API Key')
     }
-    const payload = Object.assign({}, options, { api_key_id: apiKeyId })
+    const payload = Object.assign({}, options, { api_key_name: apiKeyName })
     return jwt.sign(payload, apiKey, { algorithm: SIGNED_SEARCH_TOKEN_JWT_ALGORITHM })
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swiftype-app-search-node",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Swiftype app-search Node.js client",
   "files": [
     "lib/"

--- a/test/test.js
+++ b/test/test.js
@@ -114,10 +114,10 @@ describe('SwiftypeAppSearchClient', () => {
 
   describe('#createSignedSearchKey', () => {
     it('should build a valid jwt', (done) => {
-      token = SwiftypeAppSearchClient.createSignedSearchKey('api-mu75psc5egt9ppzuycnc2mc3', 42, { query: 'cat' })
+      token = SwiftypeAppSearchClient.createSignedSearchKey('api-mu75psc5egt9ppzuycnc2mc3', 'my-token-name', { query: 'cat' })
       jwt = require('jsonwebtoken')
       decoded = jwt.verify(token, 'api-mu75psc5egt9ppzuycnc2mc3')
-      assert.equal(decoded.api_key_id, 42)
+      assert.equal(decoded.api_key_name, 'my-token-name')
       assert.equal(decoded.query, 'cat')
       done()
     })


### PR DESCRIPTION
This is a breaking change.

We're going to stop exposing API Key id's in the dashboard, and rely on the `name` attribute instead.