### PR TITLE
Fix signed search keys

### DIFF
--- a/fixtures/host-c5s2mj.api.swiftype.com-443/15193573244029391
+++ b/fixtures/host-c5s2mj.api.swiftype.com-443/15193573244029391
@@ -2,7 +2,7 @@ POST /api/as/v1/engines/swiftype-api-example/documents
 content-type: application/json
 host: host-c5s2mj.api.swiftype.com
 x-swiftype-client: swiftype-app-search-node
-x-swiftype-client-version: 0.3.0
+x-swiftype-client-version: 0.3.1
 authorization: Bearer api-mu75psc5egt9ppzuycnc2mc3
 accept: application/json
 body: [{\"id\":\"INscMGmhmX4\",\"url\":\"http://www.youtube.com/watch?v=v1uyQZNg2vE\",\"title\":\"The Original Grumpy Cat\",\"body\":\"this is a test\"},{\"id\":\"JNDFojsd02\",\"url\":\"http://www.youtube.com/watch?v=tsdfhk2j\",\"title\":\"Another Grumpy Cat\",\"body\":\"this is also a test\"}]

--- a/fixtures/host-c5s2mj.api.swiftype.com-443/151935732448113219
+++ b/fixtures/host-c5s2mj.api.swiftype.com-443/151935732448113219
@@ -2,7 +2,7 @@ GET /api/as/v1/engines/swiftype-api-example/documents
 content-type: application/json
 host: host-c5s2mj.api.swiftype.com
 x-swiftype-client: swiftype-app-search-node
-x-swiftype-client-version: 0.3.0
+x-swiftype-client-version: 0.3.1
 authorization: Bearer api-mu75psc5egt9ppzuycnc2mc3
 accept: application/json
 body: [\"INscMGmhmX4\",\"JNDFojsd02\"]

--- a/fixtures/host-c5s2mj.api.swiftype.com-443/151935732459996374
+++ b/fixtures/host-c5s2mj.api.swiftype.com-443/151935732459996374
@@ -2,7 +2,7 @@ DELETE /api/as/v1/engines/swiftype-api-example/documents
 content-type: application/json
 host: host-c5s2mj.api.swiftype.com
 x-swiftype-client: swiftype-app-search-node
-x-swiftype-client-version: 0.3.0
+x-swiftype-client-version: 0.3.1
 authorization: Bearer api-mu75psc5egt9ppzuycnc2mc3
 accept: application/json
 body: [\"INscMGmhmX4\",\"FakeId\"]

--- a/fixtures/host-c5s2mj.api.swiftype.com-443/151935732470971687
+++ b/fixtures/host-c5s2mj.api.swiftype.com-443/151935732470971687
@@ -2,7 +2,7 @@ GET /api/as/v1/engines/swiftype-api-example/search
 content-type: application/json
 host: host-c5s2mj.api.swiftype.com
 x-swiftype-client: swiftype-app-search-node
-x-swiftype-client-version: 0.3.0
+x-swiftype-client-version: 0.3.1
 authorization: Bearer api-mu75psc5egt9ppzuycnc2mc3
 accept: application/json
 body: {\"query\":\"cat\"}

--- a/fixtures/host-c5s2mj.api.swiftype.com-443/15208899348639621
+++ b/fixtures/host-c5s2mj.api.swiftype.com-443/15208899348639621
@@ -2,7 +2,7 @@ POST /api/as/v1/engines/swiftype-api-example/documents
 content-type: application/json
 host: host-c5s2mj.api.swiftype.com
 x-swiftype-client: swiftype-app-search-node
-x-swiftype-client-version: 0.3.0
+x-swiftype-client-version: 0.3.1
 authorization: Bearer api-mu75psc5egt9ppzuycnc2mc3
 accept: application/json
 body: [{\"id\":\"INscMGmhmX4\",\"url\":\"http://www.youtube.com/watch?v=v1uyQZNg2vE\",\"title\":\"The Original Grumpy Cat\",\"body\":\"this is a test\"}]

--- a/fixtures/host-c5s2mj.api.swiftype.com-443/152643363747751014
+++ b/fixtures/host-c5s2mj.api.swiftype.com-443/152643363747751014
@@ -2,7 +2,7 @@ GET /api/as/v1/engines
 content-type: application/json
 host: host-c5s2mj.api.swiftype.com
 x-swiftype-client: swiftype-app-search-node
-x-swiftype-client-version: 0.3.0
+x-swiftype-client-version: 0.3.1
 authorization: Bearer api-mu75psc5egt9ppzuycnc2mc3
 
 HTTP/1.1 200 OK

--- a/fixtures/host-c5s2mj.api.swiftype.com-443/152643460487616422
+++ b/fixtures/host-c5s2mj.api.swiftype.com-443/152643460487616422
@@ -2,7 +2,7 @@ GET /api/as/v1/engines/swiftype-api-example
 content-type: application/json
 host: host-c5s2mj.api.swiftype.com
 x-swiftype-client: swiftype-app-search-node
-x-swiftype-client-version: 0.3.0
+x-swiftype-client-version: 0.3.1
 authorization: Bearer api-mu75psc5egt9ppzuycnc2mc3
 accept: application/json
 body: {}

--- a/fixtures/host-c5s2mj.api.swiftype.com-443/152643531437267705
+++ b/fixtures/host-c5s2mj.api.swiftype.com-443/152643531437267705
@@ -2,7 +2,7 @@ POST /api/as/v1/engines
 content-type: application/json
 host: host-c5s2mj.api.swiftype.com
 x-swiftype-client: swiftype-app-search-node
-x-swiftype-client-version: 0.3.0
+x-swiftype-client-version: 0.3.1
 authorization: Bearer api-mu75psc5egt9ppzuycnc2mc3
 accept: application/json
 body: {\"name\":\"new-engine\"}

--- a/fixtures/host-c5s2mj.api.swiftype.com-443/152643588771342928
+++ b/fixtures/host-c5s2mj.api.swiftype.com-443/152643588771342928
@@ -2,7 +2,7 @@ DELETE /api/as/v1/engines/new-engine
 content-type: application/json
 host: host-c5s2mj.api.swiftype.com
 x-swiftype-client: swiftype-app-search-node
-x-swiftype-client-version: 0.3.0
+x-swiftype-client-version: 0.3.1
 authorization: Bearer api-mu75psc5egt9ppzuycnc2mc3
 accept: application/json
 body: {}

--- a/fixtures/host-c5s2mj.api.swiftype.com-443/152666640463285327
+++ b/fixtures/host-c5s2mj.api.swiftype.com-443/152666640463285327
@@ -2,7 +2,7 @@ GET /api/as/v1/engines?page[current]=2&page[size]=1
 content-type: application/json
 host: host-c5s2mj.api.swiftype.com
 x-swiftype-client: swiftype-app-search-node
-x-swiftype-client-version: 0.3.0
+x-swiftype-client-version: 0.3.1
 authorization: Bearer api-mu75psc5egt9ppzuycnc2mc3
 accept: application/json
 body: {}

--- a/lib/swiftypeAppSearch.js
+++ b/lib/swiftypeAppSearch.js
@@ -149,9 +149,6 @@ class SwiftypeAppSearchClient {
    * @returns {String} jwt search key
    */
   static createSignedSearchKey(apiKey, apiKeyName, options = {}) {
-    if (!apiKey.match(/^api/)) {
-      throw new Error('Must sign search options with an API Key, cannot use a search-only API Key')
-    }
     const payload = Object.assign({}, options, { api_key_name: apiKeyName })
     return jwt.sign(payload, apiKey, { algorithm: SIGNED_SEARCH_TOKEN_JWT_ALGORITHM })
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swiftype-app-search-node",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Swiftype app-search Node.js client",
   "files": [
     "lib/"

--- a/test/test.js
+++ b/test/test.js
@@ -216,9 +216,9 @@ describe('SwiftypeAppSearchClient', () => {
 
   describe('#createSignedSearchKey', () => {
     it('should build a valid jwt', (done) => {
-      token = SwiftypeAppSearchClient.createSignedSearchKey('api-mu75psc5egt9ppzuycnc2mc3', 'my-token-name', { query: 'cat' })
+      token = SwiftypeAppSearchClient.createSignedSearchKey('private-mu75psc5egt9ppzuycnc2mc3', 'my-token-name', { query: 'cat' })
       jwt = require('jsonwebtoken')
-      decoded = jwt.verify(token, 'api-mu75psc5egt9ppzuycnc2mc3')
+      decoded = jwt.verify(token, 'private-mu75psc5egt9ppzuycnc2mc3')
       assert.equal(decoded.api_key_name, 'my-token-name')
       assert.equal(decoded.query, 'cat')
       done()


### PR DESCRIPTION
Fixes #17 

This method was explicitly requiring key values to start with
'api', which is legacy syntax. The current prefix is 'private',
which this library was rejecting.

Rather than fixing this check, I removed it completely. We will
rely on the server to validate the key that was used.