### PR TITLE
Update tests to match current API behavior

### DIFF
--- a/fixtures/host-c5s2mj.api.swiftype.com-443/151935732459996374
+++ b/fixtures/host-c5s2mj.api.swiftype.com-443/151935732459996374
@@ -20,4 +20,4 @@ x-runtime: 0.111995
 connection: close
 transfer-encoding: chunked
 
-[{"id":"INscMGmhmX4","result":true},{"id":"FakeId","result":false}]
+[{"id":"INscMGmhmX4","deleted":true},{"id":"FakeId","deleted":false}]

--- a/fixtures/host-c5s2mj.api.swiftype.com-443/152643363747751014
+++ b/fixtures/host-c5s2mj.api.swiftype.com-443/152643363747751014
@@ -23,4 +23,4 @@ x-swiftype-datacenter: dal05
 x-swiftype-frontend-node: web02.dal05
 x-swiftype-edge-node: web02.dal05
 
-{"meta":{"page":{"current":1,"total_pages":1,"total_results":3,"size":25}},"results":[{"name":"node-modules"},{"name":"ruby-gems"},{"name":"test-engine"}]}
+{"meta":{"page":{"current":1,"total_pages":1,"total_results":3,"size":25}},"results":[{"name":"node-modules","type":"default","language":null},{"name":"ruby-gems","type":"default","language":null},{"name":"test-engine","type":"default","language":null}]}

--- a/fixtures/host-c5s2mj.api.swiftype.com-443/152643460487616422
+++ b/fixtures/host-c5s2mj.api.swiftype.com-443/152643460487616422
@@ -25,4 +25,4 @@ x-swiftype-datacenter: dal05
 x-swiftype-frontend-node: web02.dal05
 x-swiftype-edge-node: web02.dal05
 
-{"name":"swiftype-api-example"}
+{"name":"swiftype-api-example","type":"default","language":null}

--- a/fixtures/host-c5s2mj.api.swiftype.com-443/152643531437267705
+++ b/fixtures/host-c5s2mj.api.swiftype.com-443/152643531437267705
@@ -25,4 +25,4 @@ x-swiftype-datacenter: dal05
 x-swiftype-frontend-node: web01.dal05
 x-swiftype-edge-node: web01.dal05
 
-{"name":"new-engine"}
+{"name":"new-engine","type":"default","language":null}

--- a/fixtures/host-c5s2mj.api.swiftype.com-443/152666640463285327
+++ b/fixtures/host-c5s2mj.api.swiftype.com-443/152666640463285327
@@ -25,4 +25,4 @@ x-swiftype-datacenter: dal05
 x-swiftype-frontend-node: web01.dal05
 x-swiftype-edge-node: web01.dal05
 
-{"meta":{"page":{"current":2,"total_pages":3,"total_results":3,"size":1}},"results":[{"name":"ruby-gems"}]}
+{"meta":{"page":{"current":2,"total_pages":3,"total_results":3,"size":1}},"results":[{"name":"ruby-gems","type":"default","language":null}]}

--- a/lib/swiftypeAppSearch.js
+++ b/lib/swiftypeAppSearch.js
@@ -118,10 +118,16 @@ class SwiftypeAppSearchClient {
    *
    * @param {String} engineName unique Engine name
    * @param {Array<String>} ids Array of document ids to be destroyed
-   * @returns {Promise<Object>} a Promise that returns a result {Object} when resolved, otherwise throws an Error.
+   * @returns {Promise<Object>} a Promise that returns a result {Object} when resolved, otherwise throws an Error. Includes "result" keys to maintain backward compatibility.
    */
   destroyDocuments(engineName, ids) {
     return this.client.delete(`engines/${encodeURIComponent(engineName)}/documents`, ids)
+    .then((response) => {
+      response.forEach((docResult)=>{
+        docResult.result = docResult.deleted
+      })
+        return response
+      })
   }
 
 

--- a/test/test.js
+++ b/test/test.js
@@ -85,8 +85,8 @@ describe('SwiftypeAppSearchClient', () => {
       swiftype.destroyDocuments(engineName, ['INscMGmhmX4', 'FakeId'])
       .then((results) => {
         assert.deepEqual([
-          { 'id': 'INscMGmhmX4', 'result': true },
-          { 'id': 'FakeId', 'result': false },
+          { 'id': 'INscMGmhmX4', 'deleted': true, 'result': true },
+          { 'id': 'FakeId', 'deleted': false, 'result': false },
         ], results)
         done()
       })
@@ -110,11 +110,17 @@ describe('SwiftypeAppSearchClient', () => {
             }
           },
           'results': [{
-            'name': 'node-modules'
+            'name': 'node-modules',
+            'type': 'default',
+            'language': null
           }, {
-            'name': 'ruby-gems'
+            'name': 'ruby-gems',
+            'type': 'default',
+            'language': null
           }, {
-            'name': 'test-engine'
+            'name': 'test-engine',
+            'type': 'default',
+            'language': null
           }]
         }, results)
         done()
@@ -142,7 +148,9 @@ describe('SwiftypeAppSearchClient', () => {
             }
           },
           'results': [{
-            'name': 'ruby-gems'
+            'name': 'ruby-gems',
+            'type': 'default',
+            'language': null
           }]
         }, results)
         done()
@@ -158,7 +166,9 @@ describe('SwiftypeAppSearchClient', () => {
       swiftype.getEngine(engineName)
       .then((results) => {
         assert.deepEqual({
-          'name': 'swiftype-api-example'
+          'name': 'swiftype-api-example',
+          'type': 'default',
+          'language': null
         }, results)
         done()
       })
@@ -173,7 +183,9 @@ describe('SwiftypeAppSearchClient', () => {
       swiftype.createEngine('new-engine')
       .then((results) => {
         assert.deepEqual({
-          'name': 'new-engine'
+          'name': 'new-engine',
+          'type': 'default',
+          'language': null
         }, results)
         done()
       })


### PR DESCRIPTION
Running tests with `REPLAY=record`, against my own Swiftype instance, resulted in slightly different results than the fixtures had.  This PR updates fixtures with latest expected API responses. It also adds functionality to `destroyDocuments` to maintain backward compatibility for users. 